### PR TITLE
UI fixes

### DIFF
--- a/lib/components/rounded_button.dart
+++ b/lib/components/rounded_button.dart
@@ -17,7 +17,7 @@ class RoundedButton extends StatelessWidget {
     this.colour,
     this.splashColour = Colors.deepOrange,
     this.height = 50.0,
-    this.width = 280.0,
+    this.width,
     this.borderColour,
     this.textColour = kBackgroundColor,
   });
@@ -26,7 +26,8 @@ class RoundedButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return FlatButton(
       height: this.height,
-      minWidth: this.width,
+      //If width is not provided, then minWidth is 75% of screen size.
+      minWidth: this.width ?? MediaQuery.of(context).size.width * 0.75,
       shape: RoundedRectangleBorder(
         side: BorderSide(
             color: kSecondaryColor,

--- a/lib/screens/give_away_screen.dart
+++ b/lib/screens/give_away_screen.dart
@@ -261,6 +261,8 @@ class _GiveAwayScreenState extends State<GiveAwayScreen> {
                       onPressed: () {
                         setState(() {
                           setExpiryTime = true;
+                          //Remove focus from other nodes, close open keyboard if any.
+                          FocusManager.instance.primaryFocus.unfocus();
                         });
                       },
                     ),
@@ -398,7 +400,7 @@ class _GiveAwayScreenState extends State<GiveAwayScreen> {
                     ),
                   ],
                 ),
-                SizedBox(height: 220.0),
+                SizedBox(height: 50.0),
                 RoundedButton(
                   title: widget.editList ? 'SAVE' : 'SHARE',
                   colour: kPrimaryColor,


### PR DESCRIPTION
- Required UI changes applied in the giveaway page.
- On opening dateTimePicker, focus from any other TextBox will be removed, thus, if any keyboard is on, it will be removed.